### PR TITLE
Ignore trailing whitespace when verifying if references are up-to-date

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,8 +202,9 @@ class WikilinkReferenceCodeLensProvider implements CodeLensProvider {
 
     return generateReferenceList(document).then((refs) => {
       let status =
-        getText(range).replace(/\r?\n|\r/g, docConfig.eol) ===
-        refs.join(docConfig.eol)
+        getText(range)
+          .replace(/\r?\n|\r/g, docConfig.eol)
+          .trimRight() === refs.join(docConfig.eol)
           ? "up to date"
           : "out of date";
 


### PR DESCRIPTION
I've encountered a bug, when a trailing newline at the end of file caused the references code lens to say "Out of date".
The issue is that expected reference list is generated by joining lines with eol, but does not have a trailing eol.

Here's what it looks like on master:
![before](https://user-images.githubusercontent.com/6932414/85776440-03932480-b721-11ea-8f18-6c584899a493.png)

Here's what it looks like with the fix:
![after](https://user-images.githubusercontent.com/6932414/85776460-0857d880-b721-11ea-8933-d8397ddde6a1.png)

P.S. I was really surprised to see the lens text displayed correctly on screenshots in #3 . So maybe this issue occurs only in certain environments? (Mine is linux machine, LF eol, spaces indent)
