### PR TITLE
Move release notes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the "foam-vscode" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## 0.1.0
+## [0.1.5] - 2020-29-06
+
+- Fix multiple issues related to excess/disappearing newlines ([#3](https://github.com/foambubble/foam-vscode/issues/3), [#5](https://github.com/foambubble/foam-vscode/issues/5), [#10](https://github.com/foambubble/foam-vscode/issues/10))
+
+## [0.1.4] - 2020-25-06
+
+- Fix flaky reference block replacement logic that would occasionally leave
+trailing fragments in the end of the document ([#3](https://github.com/foambubble/foam-vscode/issues/3))
+
+## 0.1.3 - 2020-25-06
+
+- Include Getting Started instructions
+
+## [0.1.2] - 2020-24-06
+
+- Update extension name.
+
+## [0.1.1] - 2020-24-06
+
+- Fix markdown link format (`link.md` to just `link`).
+
+## [0.1.0] - 2020-24-06
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -34,31 +34,4 @@ Unused aren't removed from reference lists until you restart VS Code. This will 
 
 ## Release Notes
 
-### 0.1.5
-
-Fix multiple issues related to excess/disappearing newlines:
-
-- https://github.com/foambubble/foam-vscode/issues/3
-- https://github.com/foambubble/foam-vscode/issues/5
-- https://github.com/foambubble/foam-vscode/issues/10
-
-### 0.1.4
-
-Fix flaky reference block replacement logic that would occasionally leave
-trailing fragments in the end of the document ([#3](https://github.com/foambubble/foam-vscode/issues/3))
-
-### 0.1.3
-
-Include Getting Started instructions
-
-### 0.1.2
-
-Update extension name.
-
-### 0.1.1
-
-Fix markdown link format (`link.md` to just `link`).
-
-### 0.1.0
-
-Initial version.
+See the [CHANGELOG](CHANGELOG.md).


### PR DESCRIPTION
Just a little tidying. This will also move the changelog to the _Changelog_ tab within VSCode's extension viewer.

Thanks for this extension!